### PR TITLE
Restore Face node

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "extern/SadTalker"]
 	path = extern/SadTalker
 	url = https://github.com/OpenTalker/SadTalker.git
+[submodule "extern/GFPGAN"]
+	path = extern/GFPGAN
+	url = https://github.com/TencentARC/GFPGAN.git

--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,7 @@ import importlib
 import os
 
 NODE_CLASS_MAPPINGS = {}
+NODE_DISPLAY_NAME_MAPPINGS = {}
 NODE_CLASS_MAPPINGS_DEBUG = {}
 
 
@@ -64,11 +65,12 @@ else:
 nodes = load_nodes()
 for node_class in nodes:
     class_name = node_class.__name__
-    class_name = node_class.__name__
-    node_name = f"{get_label(class_name)} (mtb)"
-    NODE_CLASS_MAPPINGS[node_name] = node_class
-    NODE_CLASS_MAPPINGS_DEBUG[node_name] = node_class.__doc__
-
+    node_label = f"{get_label(class_name)} (mtb)"
+    NODE_CLASS_MAPPINGS[node_label] = node_class
+    NODE_DISPLAY_NAME_MAPPINGS[class_name] = node_label
+    NODE_CLASS_MAPPINGS_DEBUG[node_label] = node_class.__doc__
+    # TODO: I removed this, I find it more convenient to write without spaces, but it breaks every of my workflows
+    # TODO (cont): and until I find a way to automate the conversion, I'll leave it like this
 
 log.info(
     f"Loaded the following nodes:\n\t"

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 import traceback
-from .log import log, blue_text, get_summary, get_label
+from .log import log, blue_text, cyan_text, get_summary, get_label
 from .utils import here
 import importlib
 import os
@@ -70,10 +70,10 @@ for node_class in nodes:
     NODE_CLASS_MAPPINGS_DEBUG[node_name] = node_class.__doc__
 
 
-log.debug(
+log.info(
     f"Loaded the following nodes:\n\t"
     + "\n\t".join(
-        f"{k}: {blue_text(get_summary(doc)) if doc else '-'}"
+        f"{cyan_text(k)}: {blue_text(get_summary(doc)) if doc else '-'}"
         for k, doc in NODE_CLASS_MAPPINGS_DEBUG.items()
     )
 )

--- a/log.py
+++ b/log.py
@@ -49,6 +49,9 @@ def mklog(name, level=base_log_level):
     ch.setFormatter(Formatter())
     logger.addHandler(ch)
 
+    # Disable log propagation
+    logger.propagate = False
+
     return logger
 
 

--- a/log.py
+++ b/log.py
@@ -27,7 +27,8 @@ class Formatter(logging.Formatter):
 
 def mklog(name, level=logging.DEBUG):
     logger = logging.getLogger(name)
-    logger.setLevel(level)
+    # set this to the highest level of all handlers
+    logger.setLevel(logging.FATAL)
     # create console handler with a higher log level
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)

--- a/log.py
+++ b/log.py
@@ -1,9 +1,14 @@
 import logging
 import re
+import os
+
+base_log_level = logging.DEBUG if os.environ.get("MTB_DEBUG") else logging.INFO
 
 
 class Formatter(logging.Formatter):
     grey = "\x1b[38;20m"
+    cyan = "\x1b[36;20m"
+    purple = "\x1b[35;20m"
     yellow = "\x1b[33;20m"
     red = "\x1b[31;20m"
     bold_red = "\x1b[31;1m"
@@ -12,8 +17,8 @@ class Formatter(logging.Formatter):
     format = "[%(name)s] | %(levelname)s -> %(message)s"
 
     FORMATS = {
-        logging.DEBUG: grey + format + reset,
-        logging.INFO: grey + format + reset,
+        logging.DEBUG: purple + format + reset,
+        logging.INFO: cyan + format + reset,
         logging.WARNING: yellow + format + reset,
         logging.ERROR: red + format + reset,
         logging.CRITICAL: bold_red + format + reset,
@@ -25,13 +30,13 @@ class Formatter(logging.Formatter):
         return formatter.format(record)
 
 
-def mklog(name, level=logging.DEBUG):
+def mklog(name, level=base_log_level):
     logger = logging.getLogger(name)
     # set this to the highest level of all handlers
-    logger.setLevel(logging.FATAL)
+    logger.setLevel(level)
     # create console handler with a higher log level
     ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
+    ch.setLevel(level)
 
     ch.setFormatter(Formatter())
 
@@ -40,7 +45,7 @@ def mklog(name, level=logging.DEBUG):
 
 
 # - The main app logger
-log = mklog(__package__)
+log = mklog(__package__, base_log_level)
 
 
 def log_user(arg):
@@ -53,6 +58,10 @@ def get_summary(docstring):
 
 def blue_text(text):
     return f"\033[94m{text}\033[0m"
+
+
+def cyan_text(text):
+    return f"\033[96m{text}\033[0m"
 
 
 def get_label(label):

--- a/log.py
+++ b/log.py
@@ -3,6 +3,13 @@ import re
 import os
 
 base_log_level = logging.DEBUG if os.environ.get("MTB_DEBUG") else logging.INFO
+print(f"Log level: {base_log_level}")
+
+
+# Custom object that discards the output
+class NullWriter:
+    def write(self, text):
+        pass
 
 
 class Formatter(logging.Formatter):
@@ -32,15 +39,16 @@ class Formatter(logging.Formatter):
 
 def mklog(name, level=base_log_level):
     logger = logging.getLogger(name)
-    # set this to the highest level of all handlers
     logger.setLevel(level)
-    # create console handler with a higher log level
+
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
+
     ch = logging.StreamHandler()
     ch.setLevel(level)
-
     ch.setFormatter(Formatter())
-
     logger.addHandler(ch)
+
     return logger
 
 

--- a/nodes/faceenhance.py
+++ b/nodes/faceenhance.py
@@ -82,7 +82,7 @@ class BGUpscaleWrapper:
     def __init__(self, upscale_model) -> None:
         self.upscale_model = upscale_model
 
-    def enhance(self, img: Image, outscale=2):
+    def enhance(self, img: Image.Image, outscale=2):
         device = model_management.get_torch_device()
         self.upscale_model.to(device)
 
@@ -143,12 +143,18 @@ class RestoreFace:
         }
 
     def do_restore(
-        self, image, model, aligned, only_center_face, weight, save_tmp_steps
+        self,
+        image: torch.Tensor,
+        model: GFPGANer,
+        aligned,
+        only_center_face,
+        weight,
+        save_tmp_steps,
     ) -> torch.Tensor:
-        image = tensor2pil(image)
-        width, height = image.size
+        pimage = tensor2pil(image)
+        width, height = pimage.size
 
-        source_img = cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
+        source_img = cv2.cvtColor(np.array(pimage), cv2.COLOR_RGB2BGR)
 
         sys.stdout = NullWriter()
         cropped_faces, restored_faces, restored_img = model.enhance(

--- a/nodes/faceenhance.py
+++ b/nodes/faceenhance.py
@@ -1,0 +1,157 @@
+from gfpgan import GFPGANer
+import cv2
+import numpy as np
+import os
+from pathlib import Path
+import folder_paths
+from basicsr.utils import imwrite
+from PIL import Image
+from ..utils import pil2tensor, tensor2pil
+import torch
+
+
+class LoadFaceEnhanceModel:
+    def __init__(self) -> None:
+        pass
+
+    @classmethod
+    def get_models_root(cls):
+        return Path(folder_paths.models_dir) / "upscale_models"
+
+    @classmethod
+    def get_models(cls):
+        models_path = cls.get_models_root()
+
+        return [
+            x
+            for x in models_path.iterdir()
+            if x.name.endswith(".pth")
+            and ("GFPGAN" in x.name or "RestoreFormer" in x.name)
+        ]
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model_name": (
+                    [x.name for x in cls.get_models()],
+                    {"default": "None"},
+                ),
+                "upscale": ("INT", {"default": 2}),
+            },
+            "optional": {"bg_model_path": ("UPSCALE_MODEL", {"default": "None"})},
+        }
+
+    RETURN_TYPES = ("FACEENHANCE_MODEL",)
+    FUNCTION = "load_model"
+    CATEGORY = "face"
+
+    def load_model(self, model_name, upscale=2, bg_upsampler="realesrgan"):
+        basic = "RestoreFormer" not in model_name
+
+        root = self.get_models_root()
+
+        return (
+            GFPGANer(
+                model_path=(root / model_name).as_posix(),
+                upscale=upscale,
+                arch="clean" if basic else "RestoreFormer",  # or original for v1.0 only
+                channel_multiplier=2,  # 1 for v1.0 only
+                bg_upsampler=None,  # TODO:"realesrgan",
+            ),
+        )
+
+
+class RestoreFace:
+    def __init__(self) -> None:
+        pass
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "restore"
+    CATEGORY = "face"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "model": ("FACEENHANCE_MODEL",),
+                # Input are aligned faces
+                "aligned": (["true", "false"], {"default": "false"}),
+                # Only restore the center face
+                "only_center_face": (["true", "false"], {"default": "false"}),
+                # Adjustable weights
+                "weight": ("FLOAT", {"default": 0.5}),
+                "save_tmp_steps": (["true", "false"], {"default": "true"}),
+            }
+        }
+
+    def restore(
+        self,
+        image: torch.Tensor,
+        model: GFPGANer,
+        aligned="false",
+        only_center_face="false",
+        weight=0.5,
+        save_tmp_steps="true",
+    ):
+        save_tmp_steps = save_tmp_steps == "true"
+        aligned = aligned == "true"
+        only_center_face = only_center_face == "true"
+
+        image = tensor2pil(image)
+        width, height = image.size
+
+        source_img = cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
+        cropped_faces, restored_faces, restored_img = model.enhance(
+            source_img,
+            has_aligned=aligned,
+            only_center_face=only_center_face,
+            paste_back=True,
+            # TODO: weight has no effect in 1.3 and 1.4 (only tested these for now...)
+            weight=weight,
+        )
+
+        if save_tmp_steps:
+            self.save_intermediate_images(cropped_faces, restored_faces, height, width)
+        output = None
+        if restored_img is not None:
+            output = Image.fromarray(cv2.cvtColor(restored_img, cv2.COLOR_BGR2RGB))
+            # imwrite(restored_img, save_restore_path)
+
+        return (pil2tensor(output),)
+
+    def get_step_image_path(self, step, idx):
+        (
+            full_output_folder,
+            filename,
+            counter,
+            _subfolder,
+            _filename_prefix,
+        ) = folder_paths.get_save_image_path(
+            f"{step}_{idx:03}",
+            folder_paths.temp_directory,
+        )
+        file = f"{filename}_{counter:05}_.png"
+
+        return os.path.join(full_output_folder, file)
+
+    def save_intermediate_images(self, cropped_faces, restored_faces, height, width):
+        for idx, (cropped_face, restored_face) in enumerate(
+            zip(cropped_faces, restored_faces)
+        ):
+            face_id = idx + 1
+            file = self.get_step_image_path("cropped_faces", face_id)
+            imwrite(cropped_face, file)
+
+            file = self.get_step_image_path("cropped_faces_restored", face_id)
+            imwrite(restored_face, file)
+
+            file = self.get_step_image_path("cropped_faces_compare", face_id)
+
+            # save comparison image
+            cmp_img = np.concatenate((cropped_face, restored_face), axis=1)
+            imwrite(cmp_img, file)
+
+
+__nodes__ = [RestoreFace, LoadFaceEnhanceModel]

--- a/nodes/faceswap.py
+++ b/nodes/faceswap.py
@@ -8,7 +8,6 @@ import folder_paths
 import glob
 import insightface
 import numpy as np
-import onnxruntime
 import os
 import tempfile
 import torch

--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -18,7 +18,7 @@ import os
 try:
     from cv2.ximgproc import guidedFilter
 except ImportError:
-    log.error("guidedFilter not found, use opencv-contrib-python")
+    log.warning("cv2.ximgproc.guidedFilter not found, use opencv-contrib-python")
 
 
 class ColorCorrect:

--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -6,7 +6,7 @@ from skimage.color import rgb2hsv, hsv2rgb
 import numpy as np
 import torchvision.transforms.functional as F
 from PIL import Image, ImageChops
-from ..utils import tensor2pil, pil2tensor, img_np_to_tensor, img_tensor_to_np
+from ..utils import tensor2pil, pil2tensor, np2tensor, tensor2np
 import cv2
 import torch
 from ..log import log
@@ -362,7 +362,7 @@ class DeglazeImage:
     FUNCTION = "deglaze_image"
 
     def deglaze_image(self, image):
-        return (img_np_to_tensor(deglaze_np_img(img_tensor_to_np(image))),)
+        return (np2tensor(deglaze_np_img(tensor2np(image))),)
 
 
 class MaskToImage:
@@ -388,7 +388,7 @@ class MaskToImage:
     FUNCTION = "render_mask"
 
     def render_mask(self, mask, color, background):
-        mask = img_tensor_to_np(mask)
+        mask = tensor2np(mask)
         mask = Image.fromarray(mask).convert("L")
 
         image = Image.new("RGBA", mask.size, color=color)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mmcv==2.0.0
 mmdet==3.0.0
 rembg==2.0.37
 facexlib==0.3.0
+basicsr==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ insightface==0.7.3
 mmcv==2.0.0
 mmdet==3.0.0
 rembg==2.0.37
+facexlib==0.3.0

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -26,6 +26,18 @@ models_to_download = {
         ],
         "destination": "insightface",
     },
+    "GFPGAN (face enhancement)": {
+        "size": 332,
+        "download_url": [
+            "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.3.pth",
+            # TODO: provide a way to selectively download models from "packs"
+            # https://github.com/TencentARC/GFPGAN/releases/download/v0.1.0/GFPGANv1.pth
+            # https://github.com/TencentARC/GFPGAN/releases/download/v0.2.0/GFPGANCleanv1-NoCE-C2.pth
+            # https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth
+            # https://github.com/TencentARC/GFPGAN/releases/download/v1.3.4/RestoreFormer.pth
+        ],
+        "destination": "upscale_models",
+    },
 }
 
 console = Console()

--- a/utils.py
+++ b/utils.py
@@ -73,14 +73,7 @@ def np2tensor(img_np):
 
 
 def tensor2np(tensor: torch.Tensor) -> np.ndarray:
-    np.clip(255.0 * tensor.cpu().numpy().squeeze(), 0, 255).astype(np.uint8)
+    return np.clip(255.0 * tensor.cpu().numpy().squeeze(), 0, 255).astype(np.uint8)
 
-
-
-
-def img_tensor_to_np(img_tensor):
-    img_tensor = img_tensor.clone()
-    img_tensor = img_tensor * 255.0
-    return img_tensor.squeeze(0).numpy().astype(np.float32)
 
 

--- a/utils.py
+++ b/utils.py
@@ -68,8 +68,14 @@ def pil2tensor(image: Image.Image) -> torch.Tensor:
     return torch.from_numpy(np.array(image).astype(np.float32) / 255.0).unsqueeze(0)
 
 
-def img_np_to_tensor(img_np):
-    return torch.from_numpy(img_np / 255.0)[None,]
+def np2tensor(img_np):
+    return torch.from_numpy(img_np.astype(np.float32) / 255.0).unsqueeze(0)
+
+
+def tensor2np(tensor: torch.Tensor) -> np.ndarray:
+    np.clip(255.0 * tensor.cpu().numpy().squeeze(), 0, 255).astype(np.uint8)
+
+
 
 
 def img_tensor_to_np(img_tensor):

--- a/utils.py
+++ b/utils.py
@@ -4,23 +4,23 @@ import torch
 from pathlib import Path
 import sys
 
+
 def add_path(path, prepend=False):
-    
     if isinstance(path, list):
         for p in path:
             add_path(p, prepend)
         return
-    
+
     if isinstance(path, Path):
         path = path.resolve().as_posix()
-    
+
     if path not in sys.path:
         if prepend:
             sys.path.insert(0, path)
         else:
             sys.path.append(path)
-    
-    
+
+
 # Get the absolute path of the parent directory of the current script
 here = Path(__file__).parent.resolve()
 
@@ -31,12 +31,17 @@ comfy_dir = here.parent.parent
 font_path = here / "font.ttf"
 
 # Add extern folder to path
-add_path(here / "extern")
-add_path(here / "extern" / "SadTalker")
+extern_root = here / "extern"
+add_path(extern_root)
+for pth in extern_root.iterdir():
+    if pth.is_dir():
+        add_path(pth)
+
 
 # Add the ComfyUI directory and custom nodes path to the sys.path list
 add_path(comfy_dir)
 add_path((comfy_dir / "custom_nodes"))
+
 
 # Tensor to PIL (grabbed from WAS Suite)
 def tensor2pil(image: torch.Tensor) -> Image.Image:
@@ -45,12 +50,27 @@ def tensor2pil(image: torch.Tensor) -> Image.Image:
     )
 
 
+# TODO: write pil2tensor counterpart (batch support)
+# def tensor2pil(image: torch.Tensor) -> Union[Image.Image, List[Image.Image]]:
+#     batch_count = 1
+#     if len(image.shape) > 3:
+#         batch_count = image.size(0)
+
+#     if batch_count == 1:
+#         return Image.fromarray(
+#             np.clip(255.0 * image.cpu().numpy().squeeze(), 0, 255).astype(np.uint8)
+#         )
+#     return [tensor2pil(image[i]) for i in range(batch_count)]
+
+
 # Convert PIL to Tensor (grabbed from WAS Suite)
 def pil2tensor(image: Image.Image) -> torch.Tensor:
     return torch.from_numpy(np.array(image).astype(np.float32) / 255.0).unsqueeze(0)
 
+
 def img_np_to_tensor(img_np):
     return torch.from_numpy(img_np / 255.0)[None,]
+
 
 def img_tensor_to_np(img_tensor):
     img_tensor = img_tensor.clone()

--- a/web/color_widget.js
+++ b/web/color_widget.js
@@ -4,34 +4,34 @@ import { app } from "/scripts/app.js";
 import { ComfyWidgets } from "/scripts/widgets.js";
 
 export function CUSTOM_INT(node, inputName, val, func, config = {}) {
-	return {
-		widget: node.addWidget(
-			"number",
-			inputName,
-			val,
-			func, 
-			Object.assign({}, { min: 0, max: 4096, step: 640, precision: 0 }, config)
-		),
-	};
+    return {
+        widget: node.addWidget(
+            "number",
+            inputName,
+            val,
+            func,
+            Object.assign({}, { min: 0, max: 4096, step: 640, precision: 0 }, config)
+        ),
+    };
 }
-const dumb_call = (v,d,node) => {
-    console.log("dumb_call", {v,d,node});
+const dumb_call = (v, d, node) => {
+    console.log("dumb_call", { v, d, node });
 }
-function isColorBright (rgb, threshold=240) {
+function isColorBright(rgb, threshold = 240) {
     const brightess = getBrightness(rgb)
-  
+
     return brightess > threshold
-  }
-  
-  function getBrightness (rgbObj) {
-    return Math.round(((parseInt(rgbObj[0]) * 299) + (parseInt(rgbObj[1]) * 587) + (parseInt(rgbObj[2]) * 114)) /1000)
-  }
-  
+}
+
+function getBrightness(rgbObj) {
+    return Math.round(((parseInt(rgbObj[0]) * 299) + (parseInt(rgbObj[1]) * 587) + (parseInt(rgbObj[2]) * 114)) / 1000)
+}
+
 
 /**
  * @returns {import("/types/litegraph").IWidget} widget
  */
-const custom = (key,val) => {
+const custom = (key, val, compute = false) => {
     /** @type {import("/types/litegraph").IWidget} */
     const widget = {}
     // widget.y = 0;
@@ -45,7 +45,7 @@ const custom = (key,val) => {
         widgetY,
         height) {
         const border = 3;
-        
+
         // draw a rect with a border and a fill color
         ctx.fillStyle = "#000";
         ctx.fillRect(0, widgetY, widgetWidth, height);
@@ -68,8 +68,8 @@ const custom = (key,val) => {
 
         // ctx.strokeStyle = "#fff";
         // ctx.strokeRect(border, widgetY + border, widgetWidth - border * 2, height - border * 2);
-        
-        
+
+
         // ctx.fillStyle = "#000";
         // ctx.fillRect(widgetWidth/2 - border / 2 , widgetY + border / 2 , widgetWidth/2 + border / 2, height + border / 2);
         // ctx.fillStyle = this.value;
@@ -78,118 +78,117 @@ const custom = (key,val) => {
     }
     widget.mouse = function (e, pos, node) {
         if (e.type === "pointerdown") {
-        console.log({e,pos,node})
-        // get widgets of type type : "COLOR"
-        const widgets = node.widgets.filter(w => w.type === "COLOR");
+            // get widgets of type type : "COLOR"
+            const widgets = node.widgets.filter(w => w.type === "COLOR");
 
-        for (const w of widgets) {
-            // color picker
-            const rect = [w.last_y, w.last_y + 32];
-            console.log({rect,pos})
-            if (pos[1] > rect[0] && pos[1] < rect[1]) {
-                console.log("color picker", node)
-                const picker = document.createElement("input");
-                picker.type = "color";
-                picker.value = this.value;
-                // picker.style.position = "absolute";
-                // picker.style.left = ( pos[0]) + "px";
-                // picker.style.top = (  pos[1]) + "px";
-                
-                // place at screen center
-                // picker.style.position = "absolute";
-                // picker.style.left = (window.innerWidth / 2) + "px";
-                // picker.style.top = (window.innerHeight / 2) + "px";
-                // picker.style.transform = "translate(-50%, -50%)";
-                // picker.style.zIndex = 1000;
-                
+            for (const w of widgets) {
+                // color picker
+                const rect = [w.last_y, w.last_y + 32];
+                if (pos[1] > rect[0] && pos[1] < rect[1]) {
+                    console.log("color picker", node)
+                    const picker = document.createElement("input");
+                    picker.type = "color";
+                    picker.value = this.value;
+                    // picker.style.position = "absolute";
+                    // picker.style.left = ( pos[0]) + "px";
+                    // picker.style.top = (  pos[1]) + "px";
+
+                    // place at screen center
+                    // picker.style.position = "absolute";
+                    // picker.style.left = (window.innerWidth / 2) + "px";
+                    // picker.style.top = (window.innerHeight / 2) + "px";
+                    // picker.style.transform = "translate(-50%, -50%)";
+                    // picker.style.zIndex = 1000;
 
 
-                document.body.appendChild(picker);
-                
-                picker.addEventListener("change", () => {
-                    this.value = picker.value;
-                    node.graph._version++;
-                    node.setDirtyCanvas(true, true);
-                    document.body.removeChild(picker);
-                });
-                
-                // simulate click with screen center
-                const pointer_event = new MouseEvent('click', {
-                    bubbles: false,
-                    // cancelable: true,
-                    pointerType: "mouse",
-                    clientX: window.innerWidth / 2,
-                    clientY: window.innerHeight / 2,
-                    x: window.innerWidth / 2,
-                    y: window.innerHeight / 2,
-                    offsetX: window.innerWidth / 2,
-                    offsetY: window.innerHeight / 2,
-                    screenX: window.innerWidth / 2,
-                    screenY: window.innerHeight / 2,
+
+                    document.body.appendChild(picker);
+
+                    picker.addEventListener("change", () => {
+                        this.value = picker.value;
+                        node.graph._version++;
+                        node.setDirtyCanvas(true, true);
+                        document.body.removeChild(picker);
+                    });
+
+                    // simulate click with screen center
+                    const pointer_event = new MouseEvent('click', {
+                        bubbles: false,
+                        // cancelable: true,
+                        pointerType: "mouse",
+                        clientX: window.innerWidth / 2,
+                        clientY: window.innerHeight / 2,
+                        x: window.innerWidth / 2,
+                        y: window.innerHeight / 2,
+                        offsetX: window.innerWidth / 2,
+                        offsetY: window.innerHeight / 2,
+                        screenX: window.innerWidth / 2,
+                        screenY: window.innerHeight / 2,
 
 
-                });
-                console.log(e)
-                picker.dispatchEvent(pointer_event);
-            
-            }}}}
+                    });
+                    console.log(e)
+                    picker.dispatchEvent(pointer_event);
+
+                }
+            }
+        }
+    }
     widget.computeSize = function (width) {
         return [width, 32];
     }
+
     return widget;
 }
 
 app.registerExtension({
     name: "mtb.ColorPicker",
-    init: () => {
-        ComfyWidgets.COLOR = function () {
-            return {
-                widget:custom("color", "#ff0000")
-            };
-        };
-    },
+
     async beforeRegisterNodeDef(nodeType, nodeData, app) {
-        
+
         //console.log("mtb.ColorPicker", { nodeType, nodeData, app });
         const rinputs = nodeData.input?.required; // object with key/value pairs, "0" is the type
         // console.log(nodeData.name, { nodeType, nodeData, app });
 
         if (!rinputs) return;
 
-       
+
         let has_color = false;
         for (const [key, input] of Object.entries(rinputs)) {
             if (input[0] === "COLOR") {
-                has_color = true;                
+                has_color = true;
                 // input[1] = { default: "#ff0000" };
-            
-            }}
+
+            }
+        }
 
         if (!has_color) return;
-        
+
         const onNodeCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
             const r = onNodeCreated ? onNodeCreated.apply(this, arguments) : undefined;
             this.serialize_widgets = true;
-        // if (rinputs[0] === "COLOR") {
-        // console.log(nodeData.name, { nodeType, nodeData, app });
+            // if (rinputs[0] === "COLOR") {
+            // console.log(nodeData.name, { nodeType, nodeData, app });
 
-        // loop through the inputs to find the color inputs
-         for (const [key, input] of Object.entries(rinputs)) {
-            if (input[0] === "COLOR") {
-                this.addCustomWidget(custom(key,input[1]))
-            }
-        // }
-         }
+            // loop through the inputs to find the color inputs
+            for (const [key, input] of Object.entries(rinputs)) {
+                if (input[0] === "COLOR") {
+                    let widget = custom(key, input[1])
 
-         this.onRemoved = function () {
-            // When removing this node we need to remove the input from the DOM
-            for (let y in this.widgets) {
-                if (this.widgets[y].canvas) {
-                    this.widgets[y].canvas.remove();
+                    this.addCustomWidget(widget)
                 }
+                // }
             }
-        };
+
+            this.onRemoved = function () {
+                // When removing this node we need to remove the input from the DOM
+                for (let y in this.widgets) {
+                    if (this.widgets[y].canvas) {
+                        this.widgets[y].canvas.remove();
+                    }
+                }
+            };
         }
     }
 });


### PR DESCRIPTION
## What changes are in this PR

- **fix**: all opened issues
	-  better log, use the env var `MTB_DEBUG=true` to enable more debugging like before.
	- separate faceswaper inference and model loader. 
- **feat**: `RestoreFace` + `LoadFaceSwapModel` nodes (using GFPGAN that was added as a submodule) 

The intermediate steps are saved in Comfy's temp dir (if enabled on the node):
![image](https://github.com/melMass/comfy_mtb/assets/7041726/e518af86-700f-4e59-9242-b27c95562b9b)
![cropped_faces_compare_001_00001_](https://github.com/melMass/comfy_mtb/assets/7041726/d0d5f1b4-4bb3-4082-9d0d-3c691184d321)


### Todo
- [ ] Test in isolation
- [x] TODOs added in code