### PR TITLE
Fix unclickable gallery buttons on firefox

### DIFF
--- a/web/imageFeed.js
+++ b/web/imageFeed.js
@@ -34,7 +34,7 @@ const styles = {
     zIndex: 9999999,
     fontSize: '30px',
     cursor: 'pointer',
-    pointerEvents: 'bounding-box',
+    pointerEvents: 'auto',
     ...extra,
   }),
   img_list: {


### PR DESCRIPTION
When opening the image gallery via the feed in Firefox, the close/next/prev buttons are not clickable.

It appears Firefox doesn't support `pointer-events: bounding-box` on buttons, I'm not sure but after a bit of research it looks like the property is SVG only, and chrome just supports it regardless.

PR changes the CSS on the buttons to `pointer-events: auto`, confirmed to work on both Firefox and Chrome.

I just started using this extension <3 love it so far, so thank you for your hard work.