### PR TITLE
Bugfix: Re-enable ColoredImage generation when foreground_image is not provided.

### DIFF
--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -541,8 +541,10 @@ class ColoredImage:
                         Image.alpha_composite(image, fg_image).convert("RGB")
                     )
 
-        elif foreground_mask is not None:
-            log.warn("Mask ignored because no foreground image is given")
+        else:
+            if foreground_mask is not None:
+                log.warn("Mask ignored because no foreground image is given")
+            output.append(image)
 
         output = pil2tensor(output)
 

--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -544,7 +544,7 @@ class ColoredImage:
         else:
             if foreground_mask is not None:
                 log.warn("Mask ignored because no foreground image is given")
-            output.append(image)
+            output.append(image.convert("RGB"))
 
         output = pil2tensor(output)
 


### PR DESCRIPTION
# Description

Re-implements ability to generate solid color images using `ColoredImage` node without providing foreground image. This appears to have been unintentionally removed in 049983dbe2dbce6b772908468c4042d2bfde5eb2.

## Demonstration

Before change:

![image](https://github.com/melMass/comfy_mtb/assets/29505970/6bb41a7c-e78e-4d62-bd59-936d9cd0794a)


```
ERROR:root:!!! Exception during processing !!!
ERROR:root:Traceback (most recent call last):
  File "C:\Users\Scott\Documents\Coding\Python\StableDiffusion\CompyUI\ComfyUI\execution.py", line 152, in recursive_execute
    output_data, output_ui = get_output_data(obj, input_data_all)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Scott\Documents\Coding\Python\StableDiffusion\CompyUI\ComfyUI\execution.py", line 82, in get_output_data
    return_values = map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Scott\Documents\Coding\Python\StableDiffusion\CompyUI\ComfyUI\execution.py", line 75, in map_node_over_list
    results.append(getattr(obj, func)(**slice_dict(input_data_all, i)))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Scott\Documents\Coding\Python\StableDiffusion\CompyUI\ComfyUI\custom_nodes\comfy_mtb\nodes\image_processing.py", line 547, in render_img
    output = pil2tensor(output)
             ^^^^^^^^^^^^^^^^^^
  File "C:\Users\Scott\Documents\Coding\Python\StableDiffusion\CompyUI\ComfyUI\custom_nodes\comfy_mtb\utils.py", line 278, in pil2tensor
    return torch.cat([pil2tensor(img) for img in image], dim=0)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: torch.cat(): expected a non-empty list of Tensors

Prompt executed in 0.66 seconds
```


After change:
![image](https://github.com/melMass/comfy_mtb/assets/29505970/dc1036d0-294b-4ac8-9b87-cebf550b3956)
