### PR TITLE
MTB_ImageCompare Node Improvements

### DIFF
--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -216,8 +216,19 @@ class MTB_ImageCompare:
     CATEGORY = "mtb/image"
 
     def compare(self, imageA: torch.Tensor, imageB: torch.Tensor, mode):
-        imageA = imageA.squeeze()
-        imageB = imageB.squeeze()
+        if imageA.dim() == 4:
+            batch_count = imageA.size(0)
+            return (
+                torch.cat(
+                    tuple(
+                        self.compare(
+                            imageA[i], imageB[i], mode
+                        )[0]
+                        for i in range(batch_count)
+                    ),
+                    dim=0,
+                ),
+            )
 
         if mode == "diff":
             compare_image = torch.abs(imageA - imageB)


### PR DESCRIPTION
**Description:**
This pull request aims to enhance the `MTB_ImageCompare` node by addressing the following issues:


1. **Skip NumPy Conversion for "blend" and "diff" Modes**
   - For the "diff" and "blend" modes, utilize the equivalent Torch methods used in `skimage.util.compare_images` instead of converting to NumPy arrays, calling `compare_images`, and then converting back to Torch tensors.

2. **Fix "checkerboard" Mode**
    - Compare each channel of the images individually using `compare_images`
    - Iterate with `range(imageA.shape[2])` so it works with RGBA images as well.

      ```python
      [
        compare_images(imageA[:, :, i], imageB[:, :, i], method=mode) 
        for i in range(imageA.shape[2])
      ]
      ```
    - Stack the results obtained from the comparison of individual channels to produce the desired output.
    - Note: `skimage.util.compare_images` expects a 2D array, but other shapes did not cause errors in "blend" and "diff" modes given how they work, which explains issue #175 (resolved by this change).
    
3. **Handle Batches**
    - Introduce recursion over the batch dimension and concatenate the results. This ensures that the function handles batches appropriately instead of always squeezing them. Not sure your philosophy on this.

Thank you for taking the time to review this pull request. I'm really impressed with this project. Appreciate your efforts and also appreciate any feedback 👍👍
