### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,11 @@ source = "git-tag"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[project]
+dependencies = ["qrcode", "onnxruntime-gpu", "requirements-parserx", "rembg", "imageio_ffmpeg", "rich", "rich_argparse", "matplotlib", "pillow",]
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "comfy-mtb"
+Icon = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,6 @@ build-backend = "poetry.core.masonry.api"
 dependencies = ["qrcode", "onnxruntime-gpu", "requirements-parserx", "rembg", "imageio_ffmpeg", "rich", "rich_argparse", "matplotlib", "pillow",]
 
 [tool.comfy]
-PublisherId = ""
+PublisherId = "mel"
 DisplayName = "comfy-mtb"
 Icon = ""


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://www.comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [x] Go to the [registry](https://www.comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [x] Merge the separate Github Actions PR and run the workflow.
If you want to publish the node manually, [install the cli](https://www.comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`


Please message me on [Discord](https://discord.com/invite/comfycontrib) if you have any questions!