### PR TITLE
Add Github Action for Publishing to Comfy Registry

### DIFF
--- a/.github/ISSUE_TEMPLATE/publish_action.yml
+++ b/.github/ISSUE_TEMPLATE/publish_action.yml
@@ -1,0 +1,21 @@
+name: Publish to Comfy registry
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "pyproject.toml"
+
+jobs:
+  publish-node:
+    name: Publish Custom Node to registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Publish Custom Node
+        uses: Comfy-Org/publish-node-action@main
+        with:
+          ## Add your own personal access token to your Github Repository secrets and reference it here.
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/.github/ISSUE_TEMPLATE/publish_action.yml
+++ b/.github/ISSUE_TEMPLATE/publish_action.yml
@@ -1,4 +1,4 @@
-name: Publish to Comfy registry
+name: 📦 Publish to Comfy registry
 on:
   workflow_dispatch:
   push:
@@ -12,10 +12,9 @@ jobs:
     name: Publish Custom Node to registry
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
+      - name: ♻️ Check out code
         uses: actions/checkout@v4
-      - name: Publish Custom Node
+      - name: 📦 Publish Custom Node
         uses: Comfy-Org/publish-node-action@main
         with:
-          ## Add your own personal access token to your Github Repository secrets and reference it here.
-          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+          personal_access_token: ${{ secrets.COMFY_REGISTRY_TOKEN }}


### PR DESCRIPTION
This PR adds a Github Action (publish-node-action) that will run whenever the pyproject.toml file changes. The pyproject.toml defines the custom node version you want to publish (added in another PR).

Action Required:

- [x] Create an api key on the Registry for publishing from Github. [Instructions](https://www.comfydocs.org/registry/overview#create-an-api-key-for-publishing).
- [x] Add it to your Github Repository Secrets as `REGISTRY_ACCESS_TOKEN`.
More info on the [registry](https://www.comfyregistry.org/). Please message me on [Discord](https://discord.com/invite/comfycontrib) if you have any questions!