### PR TITLE
Fix input type on MTB_AnyToString

### DIFF
--- a/nodes/graph_utils.py
+++ b/nodes/graph_utils.py
@@ -417,7 +417,7 @@ class MTB_AnyToString:
     @classmethod
     def INPUT_TYPES(cls):
         return {
-            "required": {"input": ("*")},
+            "required": {"input": ("*",)},
         }
 
     RETURN_TYPES = ("STRING",)


### PR DESCRIPTION
For performance reason, we disabled the node def validation by default, and the auto-conversion of somewhat wrong, types are no longer supported by default.

This PR fixes the input type to a proper format that will work both with/without validation conversion.