### PR TITLE
Use local import for Rembg

### DIFF
--- a/nodes/mask.py
+++ b/nodes/mask.py
@@ -1,6 +1,5 @@
 import comfy.utils
 from PIL import Image
-from rembg import remove
 
 from ..utils import pil2tensor, tensor2pil
 
@@ -64,6 +63,8 @@ class MTB_ImageRemoveBackgroundRembg:
         post_process_mask,
         bgcolor,
     ):
+        from rembg import remove
+
         pbar = comfy.utils.ProgressBar(image.size(0))
         images = tensor2pil(image)
 


### PR DESCRIPTION
Rembg can sometimes cause *very* long load times on import (like 40s). Moving it to local doesn't fix the long import entirely, but it does prevent it causing ComfyUI from loading slowly.