### PR TITLE
Checkout submodules before publishing.

### DIFF
--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: ♻️ Check out code
         uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: 📦 Publish Custom Node
         uses: Comfy-Org/publish-node-action@main
         with:

--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@
 #
 ###
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 import os
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfy-mtb"
-version = "0.2.0"
+version = "0.2.1"
 description = "Animation oriented nodes pack for ComfyUI."
 license = "MIT"
 readme = "README.md"
@@ -63,7 +63,7 @@ DisplayName = "comfy-mtb"
 Icon = "https://avatars.githubusercontent.com/u/7041726?v=4"
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.2.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/utils.py
+++ b/utils.py
@@ -513,9 +513,10 @@ font_path = here / "data" / "font.ttf"
 extern_root = here / "extern"
 add_path(extern_root)
 
-for pth in extern_root.iterdir():
-    if pth.is_dir():
-        add_path(pth)
+if extern_root.exists():
+    for pth in extern_root.iterdir():
+        if pth.is_dir():
+            add_path(pth)
 
 # - Add the ComfyUI directory and custom nodes path to the sys.path list
 add_path(comfy_dir)


### PR DESCRIPTION
Hey Mel! As I was testing your node on registry I realized that we never bundle the `extern` folder. After some digging, I realized it's because git clone will automatically check out the extern sub repositories. However, the checkout action does not. 

Can we merge this and then publish a new version? The previous versions don't work so we can delete those as well if you prefer.