### PR TITLE
feat: ✨ live update outputs sidebar

### DIFF
--- a/types/typedefs.js
+++ b/types/typedefs.js
@@ -16,3 +16,50 @@
  * @typedef {import("./shared.d.ts").INodeOutputSlot} INodeOutputSlot
  */
 
+/**
+ * @typedef {Object} ResultItem
+ * @property {string} [filename] - The filename of the item.
+ * @property {string} [subfolder] - The subfolder of the item.
+ * @property {string} [type] - The type of the item.
+ */
+
+/**
+ * @typedef {Object} Outputs
+ * @property {ResultItem[]} [audio] - Audio result items.
+ * @property {ResultItem[]} [images] - Image result items.
+ * @property {ResultItem[]} [animated] - Animated result items.
+ */
+
+/**
+ * @typedef {Record<string, Outputs>} TaskOutput
+ * - A record mapping Node IDs to their Outputs.
+ */
+
+/**
+ * @typedef {Array} TaskPrompt
+ * @property {QueueIndex} [0] - The queue index.
+ * @property {PromptId} [1] - The unique prompt ID.
+ * @property {PromptInputs} [2] - The prompt inputs.
+ * @property {ExtraData} [3] - Extra data.
+ * @property {OutputsToExecute} [4] - The outputs to execute.
+ */
+
+/**
+ * @typedef {Object} HistoryTaskItem
+ * @property {'History'} taskType - The type of task.
+ * @property {TaskPrompt} prompt - The task prompt.
+ * @property {Status} [status] - The status of the task.
+ * @property {TaskOutput} outputs - The task outputs.
+ * @property {TaskMeta} [meta] - Optional task metadata.
+ */
+
+/**
+ * @typedef {Object} ExecInfo
+ * @property {number} queue_remaining - The number of items remaining in the queue.
+ */
+
+/**
+ * @typedef {Object} StatusWsMessageStatus
+ * @property {ExecInfo} exec_info - Execution information.
+ */
+


### PR DESCRIPTION
Hi Mel, what do you think of something like this? This makes the grid live-update while in output mode.

The code in this PR adds a listener for the 'status' event. In the callback, it fetches the most recent history item and prepends any new outputs to the grid. This is the same implementation as ComfyUI_frontend queue except less demanding since we only need to process 1 history item (most recent) at a time.


https://github.com/user-attachments/assets/53b42314-459d-4146-9547-7333f87f0590

The types were converted from [apiTypes.ts](https://github.com/Comfy-Org/ComfyUI_frontend/blob/11258f4a957fa47a9654d55bb07ec55607c97fd4/src/stores/queueStore.ts#L20) by ChatGPT. 