### PR TITLE
Set widgetType for COLOR widgets

### DIFF
--- a/nodes/generate.py
+++ b/nodes/generate.py
@@ -193,11 +193,11 @@ by default it fallsback to a default font.
                 ),
                 "color": (
                     "COLOR",
-                    {"default": "black"},
+                    {"default": "black", "widgetType": "MTB_COLOR"},
                 ),
                 "background": (
                     "COLOR",
-                    {"default": "white"},
+                    {"default": "white", "widgetType": "MTB_COLOR"},
                 ),
                 "h_align": (("left", "center", "right"), {"default": "left"}),
                 "v_align": (("top", "center", "bottom"), {"default": "top"}),

--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -879,8 +879,11 @@ class MTB_MaskToImage:
         return {
             "required": {
                 "mask": ("MASK",),
-                "color": ("COLOR",),
-                "background": ("COLOR", {"default": "#000000"}),
+                "color": ("COLOR", {"widgetType": "MTB_COLOR"}),
+                "background": (
+                    "COLOR",
+                    {"default": "#000000", "widgetType": "MTB_COLOR"},
+                ),
             },
             "optional": {
                 "invert": ("BOOLEAN", {"default": False}),

--- a/nodes/transform.py
+++ b/nodes/transform.py
@@ -43,7 +43,10 @@ class MTB_TransformImage:
                     ["edge", "constant", "reflect", "symmetric"],
                     {"default": "edge"},
                 ),
-                "constant_color": ("COLOR", {"default": "#000000"}),
+                "constant_color": (
+                    "COLOR",
+                    {"default": "#000000", "widgetType": "MTB_COLOR"},
+                ),
             },
             "optional": {
                 "filter_type": (


### PR DESCRIPTION
Changes all color inputs to use the namespaced widget constructor. This restores functionality of all mtb nodes with color widgets.