### PR TITLE
whisper transcription compatibility with newer transformers

### DIFF
--- a/nodes/audio.py
+++ b/nodes/audio.py
@@ -277,14 +277,14 @@ class MTB_AudioToText(MtbAudio):
                 f"Processing chunk {chunk_offset:.1f}s - {chunk_end / sample_rate:.1f}s"
             )
 
-            max_length = model.config.max_length or 448
+            max_length = getattr(model.config, "max_length", None) or 448
             attention_mask = torch.ones((1, max_length))
 
             input_features = processor(
                 chunk_waveform,
                 sampling_rate=sample_rate,
                 return_tensors="pt",
-            ).input_features.to(device)
+            ).input_features.to(device=device, dtype=model.dtype)
 
             with torch.no_grad():
                 predicted_ids = model.generate(


### PR DESCRIPTION
- Fix WhisperConfig max_length AttributeError — Newer versions of the transformers library removed the max_length attribute from WhisperConfig, causing transcription to crash with AttributeError: 'WhisperConfig' object has no attribute 'max_length'. Changed to use getattr() with a fallback so it works on both old and new versions of transformers.
- Fix float16 dtype mismatch — When running Whisper in half precision (float16), the input_features tensor was being passed as float32, causing a RuntimeError: Input type (float) and bias type (struct c10::Half) should be the same. Now the input features are cast to match the model's dtype before inference.