### PR TITLE
fix the typo of Distinctions-646 model name which leads to 404 err when using this node to download vitmatte_b_dis.pt from hf

### DIFF
--- a/nodes/vitmatte.py
+++ b/nodes/vitmatte.py
@@ -27,7 +27,7 @@ class MTB_LoadVitMatteModel:
     def execute(self, *, kind: str, autodownload: bool):
         dest = models_dir / "vitmatte"
         dest.mkdir(exist_ok=True)
-        name = "dist" if kind == "Distinctions-646" else "com"
+        name = "dis" if kind == "Distinctions-646" else "com"
 
         file = hf_hub_download(
             repo_id="melmass/pytorch-scripts",


### PR DESCRIPTION
When I tried to use the node "Load Vit Matte Model (mtb)", I kept getting 404 err while auto-downloading the Distinctions-646 model from huggingface, so I checked the hf repo and found the model manually.
<img width="1316" height="721" alt="image" src="https://github.com/user-attachments/assets/169c7aa2-2280-4fb1-be17-ee313c377036" />
Then I checked the source code of the node, and found that it is caused by model name mismatch, the source code use the model name "vitmatte_b_dist.pt" while the actual model name in hf is "vitmatte_b_dis.pt". After fixing the model name problem, I tried locally on my device and it works perfectly now.